### PR TITLE
fix nftables interface matching

### DIFF
--- a/pkg/nftables/nftables.tpl
+++ b/pkg/nftables/nftables.tpl
@@ -30,12 +30,12 @@ table ip firewall {
 		type filter hook forward priority 1; policy drop;
 
 		# network traffic accounting for external traffic
-		ip saddr != @internal_prefixes oif vlan{{ .PrivateVrfID }} counter name external_in
-		ip daddr != @internal_prefixes iif vrf{{ .PrivateVrfID }} counter name external_out
+		ip saddr != @internal_prefixes oifname "vlan{{ .PrivateVrfID }}" counter name external_in
+		ip daddr != @internal_prefixes iifname "vrf{{ .PrivateVrfID }}" counter name external_out
 
 		# network traffic accounting for internal traffic
-		ip saddr @internal_prefixes oif vlan{{ .PrivateVrfID }} counter name internal_in
-		ip daddr @internal_prefixes iif vrf{{ .PrivateVrfID }} counter name internal_out
+		ip saddr @internal_prefixes oifname "vlan{{ .PrivateVrfID }}" counter name internal_in
+		ip daddr @internal_prefixes iifname "vrf{{ .PrivateVrfID }}" counter name internal_out
 
 		# rate limits
 		{{- range .RateLimits }}

--- a/pkg/nftables/test_data/more-rules.nftable.v4
+++ b/pkg/nftables/test_data/more-rules.nftable.v4
@@ -30,12 +30,12 @@ table ip firewall {
 		type filter hook forward priority 1; policy drop;
 
 		# network traffic accounting for external traffic
-		ip saddr != @internal_prefixes oif vlan42 counter name external_in
-		ip daddr != @internal_prefixes iif vrf42 counter name external_out
+		ip saddr != @internal_prefixes oifname "vlan42" counter name external_in
+		ip daddr != @internal_prefixes iifname "vrf42" counter name external_out
 
 		# network traffic accounting for internal traffic
-		ip saddr @internal_prefixes oif vlan42 counter name internal_in
-		ip daddr @internal_prefixes iif vrf42 counter name internal_out
+		ip saddr @internal_prefixes oifname "vlan42" counter name internal_in
+		ip daddr @internal_prefixes iifname "vrf42" counter name internal_out
 
 		# rate limits
 		meta iifname "eth0" limit rate over 10 mbytes/second counter name drop_ratelimit drop

--- a/pkg/nftables/test_data/simple.nftable.v4
+++ b/pkg/nftables/test_data/simple.nftable.v4
@@ -30,12 +30,12 @@ table ip firewall {
 		type filter hook forward priority 1; policy drop;
 
 		# network traffic accounting for external traffic
-		ip saddr != @internal_prefixes oif vlan42 counter name external_in
-		ip daddr != @internal_prefixes iif vrf42 counter name external_out
+		ip saddr != @internal_prefixes oifname "vlan42" counter name external_in
+		ip daddr != @internal_prefixes iifname "vrf42" counter name external_out
 
 		# network traffic accounting for internal traffic
-		ip saddr @internal_prefixes oif vlan42 counter name internal_in
-		ip daddr @internal_prefixes iif vrf42 counter name internal_out
+		ip saddr @internal_prefixes oifname "vlan42" counter name internal_in
+		ip daddr @internal_prefixes iifname "vrf42" counter name internal_out
 
 		# rate limits
 		meta iifname "eth0" limit rate over 10 mbytes/second counter name drop_ratelimit drop

--- a/pkg/nftables/test_data/validated.nftable.v4
+++ b/pkg/nftables/test_data/validated.nftable.v4
@@ -30,12 +30,12 @@ table ip firewall {
 		type filter hook forward priority 1; policy drop;
 
 		# network traffic accounting for external traffic
-		ip saddr != @internal_prefixes oif vlan42 counter name external_in
-		ip daddr != @internal_prefixes iif vrf42 counter name external_out
+		ip saddr != @internal_prefixes oifname "vlan42" counter name external_in
+		ip daddr != @internal_prefixes iifname "vrf42" counter name external_out
 
 		# network traffic accounting for internal traffic
-		ip saddr @internal_prefixes oif vlan42 counter name internal_in
-		ip daddr @internal_prefixes iif vrf42 counter name internal_out
+		ip saddr @internal_prefixes oifname "vlan42" counter name internal_in
+		ip daddr @internal_prefixes iifname "vrf42" counter name internal_out
 
 		# rate limits
 


### PR DESCRIPTION
Ensure nftables gets executed even if the given interfaces are not ready yet.

According to: https://wiki.nftables.org/wiki-nftables/index.php/Matching_packet_metainformation

the difference between iif and ifname is that the later will not break if the interface is not ready yet.

Otherwise we see the following after a hard reboot of the firewall:

```
- Reboot --
Aug 06 07:55:39 shoot--ph2j95--mwen-r1-firewall-c4c55 nft[912]: In file included from /etc/nftables.conf:5:1-26:
Aug 06 07:55:39 shoot--ph2j95--mwen-r1-firewall-c4c55 nft[912]: /etc/nftables/firewall-controller.v4:33:38-43: Error: Interface does not exist
Aug 06 07:55:39 shoot--ph2j95--mwen-r1-firewall-c4c55 nft[912]:                 ip saddr != @internal_prefixes oif vlan30 counter name external_in
```