### PR TITLE
Add a CLI-flag to exclude IDS

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -3,30 +3,32 @@
 1. download kubebuilder
 1. download kustomize from [kustomize](https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz)
 1. init project and run kubebuilder
-
-```bash
-kubebuilder init --domain metal-stack.io
-kubebuilder create api --group firewall --version v1 --kind Network
-```
-
+   ```bash
+   kubebuilder init --domain metal-stack.io
+   kubebuilder create api --group firewall --version v1 --kind Network
+   ```
 1. run test
-
-```bash
-export KUBEBUILDER_ASSETS=~/dev/kubebuilder_2.3.1_linux_amd64/bin
-make test
-```
+   ```bash
+   export KUBEBUILDER_ASSETS=/usr/local/kubebuilder/bin # path-to-kubebuilder/bin
+   make test
+   ```
 
 ## Testing locally
 
 ```bash
-# start kind cluster
+# make binary
+make
+
+# start the controller
+bin/firewall-controller --hosts-file ./hosts
+
+# install kind (k8s in docker)
+
+# create a local kind cluster
 kind create cluster
 
 # deploy manifests
 k apply -f deploy
-
-# start the controller
-bin/firewall-controller --hosts-file ./hosts
 
 # watch results
 k describe -n firewall firewall

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	var (
 		metricsAddr          string
 		enableLeaderElection bool
+		enableIDS            bool
 		hostsFile            string
 		serviceIP            string
 		privateVrfID         int64
@@ -65,6 +66,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableIDS, "enable-IDS", true, "Set this to false to exclude IDS.")
 	flag.StringVar(&hostsFile, "hosts-file", "/etc/hosts", "The hosts file to manipulate for the droptailer.")
 	flag.StringVar(&serviceIP, "service-ip", "172.17.0.1", "The ip where firewall services are exposed.")
 	flag.Int64Var(&privateVrfID, "private-vrf", 0, "the vrf id of the private network.")
@@ -144,6 +146,7 @@ func main() {
 		Scheme:       mgr.GetScheme(),
 		ServiceIP:    serviceIP,
 		PrivateVrfID: privateVrfID,
+		EnableIDS:    enableIDS,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Firewall")
 		os.Exit(1)


### PR DESCRIPTION
It's a feature required by @mwindower and was tested with
```bash
bin/firewall-controller --hosts-file ./hosts --enable-IDS=false
k apply -f deploy # local kind cluster
k describe -n firewall firewall
```
No IDS-related warnings in Events any more.