### PR TITLE
add app label to the exporter services

### DIFF
--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -70,6 +70,7 @@ const (
 	nodeExporterService       = "nftables-exporter"
 	nodeExporterNamedPort     = "nftexporter"
 	nodeExporterPort          = 9630
+	exporterLabelKey          = "app"
 )
 
 var done = ctrl.Result{}
@@ -321,6 +322,7 @@ func (r *FirewallReconciler) reconcileFirewallService(ctx context.Context, s fir
 	meta := metav1.ObjectMeta{
 		Name:      s.name,
 		Namespace: firewallNamespace,
+		Labels:    map[string]string{exporterLabelKey: s.name},
 	}
 
 	var currentSvc v1.Service


### PR DESCRIPTION
adds an app label to the exporter services in the firewall namespace, e.g.:

```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: node-exporter
  name: node-exporter
  namespace: firewall
```
This is needed, so for example a prometheus-operator servicemonitor can select on these services:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: firewall-node-exporter
  namespace: firewall
  labels:
    release: prometheus
spec:
  selector:
    matchLabels:
      app: node-exporter
  namespaceSelector:
    matchNames:
    - firewall
  endpoints:
  - port: nodeexporter

```