### PR TITLE
reconcile firewall exporter service labels

### DIFF
--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -354,7 +354,7 @@ func (r *FirewallReconciler) reconcileFirewallService(ctx context.Context, s fir
 		}
 	}
 
-	if !reflect.DeepEqual(currentSvc.Spec, svc.Spec) || !reflect.DeepEqual(currentSvc.ObjectMeta.Labels, svc.ObjectMeta.Labels) {
+	if !reflect.DeepEqual(currentSvc.Spec, svc.Spec) || currentSvc.ObjectMeta.Labels == nil || !reflect.DeepEqual(currentSvc.ObjectMeta.Labels, svc.ObjectMeta.Labels) {
 		currentSvc.Spec = svc.Spec
 		currentSvc.ObjectMeta.Labels = svc.ObjectMeta.Labels
 		err = r.Update(ctx, &currentSvc)

--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -354,8 +354,9 @@ func (r *FirewallReconciler) reconcileFirewallService(ctx context.Context, s fir
 		}
 	}
 
-	if !reflect.DeepEqual(currentSvc.Spec, svc.Spec) {
+	if !reflect.DeepEqual(currentSvc.Spec, svc.Spec) || !reflect.DeepEqual(currentSvc.ObjectMeta.Labels, svc.ObjectMeta.Labels) {
 		currentSvc.Spec = svc.Spec
+		currentSvc.ObjectMeta.Labels = svc.ObjectMeta.Labels
 		err = r.Update(ctx, &currentSvc)
 		if err != nil {
 			return err


### PR DESCRIPTION
Follow up to https://github.com/metal-stack/firewall-controller/pull/49

In clusters, which already have the firewall exporter services, the new labels currently do not get added.

With this PR, the firewall-exporter-services get reconciled also on metada.labels changes.