### PR TITLE
add view aggregate clusterrole

### DIFF
--- a/api/v1/clusterwidenetworkpolicy_types.go
+++ b/api/v1/clusterwidenetworkpolicy_types.go
@@ -29,6 +29,7 @@ import (
 
 // ClusterwideNetworkPolicy contains the desired state for a cluster wide network policy to be applied.
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=cwnp
 // +kubebuilder:subresource:status
 type ClusterwideNetworkPolicy struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/firewall_types.go
+++ b/api/v1/firewall_types.go
@@ -30,6 +30,7 @@ import (
 
 // Firewall is the Schema for the firewalls API
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=fw
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Interval",type=string,JSONPath=`.spec.interval`
 // +kubebuilder:printcolumn:name="InternalPrefixes",type=string,JSONPath=`.spec.internalprefixes`

--- a/config/crd/bases/metal-stack.io_clusterwidenetworkpolicies.yaml
+++ b/config/crd/bases/metal-stack.io_clusterwidenetworkpolicies.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ClusterwideNetworkPolicy
     listKind: ClusterwideNetworkPolicyList
     plural: clusterwidenetworkpolicies
+    shortNames:
+    - cwnp
     singular: clusterwidenetworkpolicy
   scope: Namespaced
   versions:

--- a/config/crd/bases/metal-stack.io_firewalls.yaml
+++ b/config/crd/bases/metal-stack.io_firewalls.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Firewall
     listKind: FirewallList
     plural: firewalls
+    shortNames:
+    - fw
     singular: firewall
   scope: Namespaced
   versions:

--- a/deploy/firewall-controller.yaml
+++ b/deploy/firewall-controller.yaml
@@ -103,7 +103,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
-  - "metal-stack.io/v1"
+  - "metal-stack.io"
   resources:
   - clusterwidenetworkpolicies
   - firewalls

--- a/deploy/firewall-controller.yaml
+++ b/deploy/firewall-controller.yaml
@@ -105,8 +105,8 @@ rules:
 - apiGroups:
   - "metal-stack.io/v1"
   resources:
-  - clusterwidenetworkpolicy
-  - firewall
+  - clusterwidenetworkpolicies
+  - firewalls
   verbs:
   - get
   - list

--- a/deploy/firewall-controller.yaml
+++ b/deploy/firewall-controller.yaml
@@ -92,6 +92,26 @@ rules:
   - create
   - delete
   - watch
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: firewall-controller-view
+  labels:
+    # With this label, all view roles will automatically get view access to this resources.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - "metal-stack.io/v1"
+  resources:
+  - ClusterwideNetworkPolicy
+  - Firewall
+  verbs:
+  - get
+  - list
+  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/firewall-controller.yaml
+++ b/deploy/firewall-controller.yaml
@@ -105,8 +105,8 @@ rules:
 - apiGroups:
   - "metal-stack.io/v1"
   resources:
-  - ClusterwideNetworkPolicy
-  - Firewall
+  - clusterwidenetworkpolicy
+  - firewall
   verbs:
   - get
   - list


### PR DESCRIPTION
In order to allow k8s users with `*-all-all-view` access our resources like cwnp and firewall add a aggregate clusterrole with a proper label to enable this permission inheritance.
Also add shortname for ClusterwideNetworkpolicy (cwnp) and Firewall (fw)

TODO:
- [x] unsure if this is the correct place, or gepm would be more appropriate, done in https://github.com/metal-stack/gardener-extension-provider-metal/pull/181

Once https://github.com/metal-stack/gardener-extension-provider-metal/pull/181 is merged, this should be merged as well