### PR TITLE
allow to disable/enable ids logs

### DIFF
--- a/api/v1/firewall_types.go
+++ b/api/v1/firewall_types.go
@@ -79,6 +79,8 @@ type Data struct {
 	EgressRules []EgressRuleSNAT `json:"egressRules,omitempty"`
 	// FirewallNetworks holds the networks known at the metal-api for this firewall machine
 	FirewallNetworks []FirewallNetwork `json:"firewallNetworks,omitempty"`
+	// EnableSuricataIDS specifies if we need to enable IDS on the firewall machine
+	EnableSuricataIDS bool `json:"enableSuricataIDS,omitempty"`
 }
 
 // FirewallStatus defines the observed state of Firewall

--- a/config/crd/bases/metal-stack.io_firewalls.yaml
+++ b/config/crd/bases/metal-stack.io_firewalls.yaml
@@ -68,6 +68,10 @@ spec:
                   - networkid
                   type: object
                 type: array
+              enableSuricataIDS:
+                description: EnableSuricataIDS specifies if we need to enable IDS
+                  on the firewall machine
+                type: boolean
               firewallNetworks:
                 description: FirewallNetworks holds the networks known at the metal-api
                   for this firewall machine

--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -40,14 +40,15 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	mn "github.com/metal-stack/metal-lib/pkg/net"
+	networking "k8s.io/api/networking/v1"
+
 	firewallv1 "github.com/metal-stack/firewall-controller/api/v1"
 	"github.com/metal-stack/firewall-controller/pkg/collector"
 	"github.com/metal-stack/firewall-controller/pkg/network"
 	"github.com/metal-stack/firewall-controller/pkg/nftables"
 	"github.com/metal-stack/firewall-controller/pkg/suricata"
 	"github.com/metal-stack/firewall-controller/pkg/updater"
-	mn "github.com/metal-stack/metal-lib/pkg/net"
-	networking "k8s.io/api/networking/v1"
 )
 
 // FirewallReconciler reconciles a Firewall object
@@ -130,16 +131,19 @@ func (r *FirewallReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	log.Info("reconciling network settings")
-	changed, err := network.ReconcileNetwork(f, log)
+	kb := network.GetUpdatedKnowledgeBase(f)
+	changed, err := network.ReconcileNetwork(kb)
 	if changed && err == nil {
 		r.recorder.Event(&f, corev1.EventTypeNormal, "Network settings", "reconcilation succeeded (frr.conf)")
 	} else if changed && err != nil {
 		r.recorder.Event(&f, corev1.EventTypeWarning, "Network settings", fmt.Sprintf("reconcilation failed (frr.conf): %v", err))
 	}
-
 	if err != nil {
 		errors = multierror.Append(errors, err)
 	}
+
+	log.Info("reconciling suricata config")
+	network.ReconcileSuricata(kb, f.Spec.EnableSuricataIDS)
 
 	log.Info("reconciling firewall services")
 	if err = r.reconcileFirewallServices(ctx, f, log); err != nil {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/go-logr/logr"
 	firewallv1 "github.com/metal-stack/firewall-controller/api/v1"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-networker/pkg/netconf"
@@ -23,11 +22,12 @@ const (
 //go:embed *.tpl
 var templates embed.FS
 
-// ReconcileNetwork reconciles the network settings for a firewall
-// in the current stage it only changes the FRR-Configuration when network prefixes or FRR template changes
-func ReconcileNetwork(f firewallv1.Firewall, log logr.Logger) (bool, error) {
-	kb := netconf.NewKnowledgeBase(MetalKnowledgeBase)
+func GetKnowledgeBase() netconf.KnowledgeBase {
+	return netconf.NewKnowledgeBase(MetalKnowledgeBase)
+}
 
+func GetUpdatedKnowledgeBase(f firewallv1.Firewall) netconf.KnowledgeBase {
+	kb := GetKnowledgeBase()
 	networkMap := map[string]firewallv1.FirewallNetwork{}
 	for _, n := range f.Spec.FirewallNetworks {
 		if n.Networktype == nil {
@@ -44,6 +44,12 @@ func ReconcileNetwork(f firewallv1.Firewall, log logr.Logger) (bool, error) {
 	}
 	kb.Networks = newNetworks
 
+	return kb
+}
+
+// ReconcileNetwork reconciles the network settings for a firewall
+// Changes both the FRR-Configuration and Nftable rules when network prefixes or FRR template changes
+func ReconcileNetwork(kb netconf.KnowledgeBase) (changed bool, err error) {
 	tmpFile, err := tmpFile(FrrConfig)
 	if err != nil {
 		return false, fmt.Errorf("error during network reconcilation %v: %w", tmpFile, err)
@@ -58,12 +64,12 @@ func ReconcileNetwork(f firewallv1.Firewall, log logr.Logger) (bool, error) {
 		return false, fmt.Errorf("error during network reconcilation: %v: %w", tmpFile, err)
 	}
 
-	changed, err := a.Apply(*tpl, tmpFile, FrrConfig, true)
+	changed, err = a.Apply(*tpl, tmpFile, FrrConfig, true)
 	if err != nil {
 		return changed, fmt.Errorf("error during network reconcilation: %v: %w", tmpFile, err)
 	}
 
-	return changed, nil
+	return
 }
 
 func tmpFile(file string) (string, error) {

--- a/pkg/network/suricata.go
+++ b/pkg/network/suricata.go
@@ -1,0 +1,15 @@
+package network
+
+import (
+	"github.com/metal-stack/metal-networker/pkg/netconf"
+)
+
+func ReconcileSuricata(kb netconf.KnowledgeBase, enableIDS bool) {
+	configurator := netconf.FirewallConfigurator{
+		CommonConfigurator: netconf.CommonConfigurator{
+			Kb: kb,
+		},
+		EnableIDS: enableIDS,
+	}
+	configurator.ConfigureSuricata()
+}


### PR DESCRIPTION
Changes to allow enabling/disabling IDS logs via firewall resource. By default logs are disabled. Depends on https://github.com/metal-stack/metal-networker/pull/59