### PR TITLE
set conntrack max and hashsize on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -304,6 +304,11 @@ func main() {
 	if err != nil {
 		l.Errorw("unable to set sysctl", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting, "error", err)
 	}
+	l.Infow("set module value", "key", sysctl.NFConntrackHashSize, "value", sysctl.NFConntrackHashSizeSetting)
+	err = sysctl.SetModule(sysctl.NFConntrackHashSize, sysctl.NFConntrackHashSizeSetting)
+	if err != nil {
+		l.Errorw("unable to set module", "key", sysctl.NFConntrackHashSize, "value", sysctl.NFConntrackHashSizeSetting, "error", err)
+	}
 
 	if err := seedMgr.Start(ctx); err != nil {
 		l.Errorw("problem running seed controller", "error", err)

--- a/main.go
+++ b/main.go
@@ -299,15 +299,9 @@ func main() {
 		}
 	}()
 
-	l.Infow("set sysctl value", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting)
-	err = sysctl.Set(sysctl.NFConntrackMax, sysctl.NFConntrackMaxSetting)
+	err = sysctl.Tune(l)
 	if err != nil {
-		l.Errorw("unable to set sysctl", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting, "error", err)
-	}
-	l.Infow("set module value", "key", sysctl.NFConntrackHashSize, "value", sysctl.NFConntrackHashSizeSetting)
-	err = sysctl.SetModule(sysctl.NFConntrackHashSize, sysctl.NFConntrackHashSizeSetting)
-	if err != nil {
-		l.Errorw("unable to set module", "key", sysctl.NFConntrackHashSize, "value", sysctl.NFConntrackHashSizeSetting, "error", err)
+		l.Errorw("unable to tune kernel", "error", err)
 	}
 
 	if err := seedMgr.Start(ctx); err != nil {

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 
 	firewallv1 "github.com/metal-stack/firewall-controller/api/v1"
 	"github.com/metal-stack/firewall-controller/controllers"
+	"github.com/metal-stack/firewall-controller/pkg/sysctl"
 	"github.com/metal-stack/firewall-controller/pkg/updater"
 	// +kubebuilder:scaffold:imports
 )
@@ -297,6 +298,11 @@ func main() {
 			l.Fatalw("problem running shoot controller", "error", err)
 		}
 	}()
+
+	err = sysctl.Set(sysctl.NFConntrackMax, sysctl.NFConntrackMaxSetting)
+	if err != nil {
+		l.Errorw("unable to set sysctl", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting, "error", err)
+	}
 
 	if err := seedMgr.Start(ctx); err != nil {
 		l.Errorw("problem running seed controller", "error", err)

--- a/main.go
+++ b/main.go
@@ -299,6 +299,7 @@ func main() {
 		}
 	}()
 
+	l.Infow("set sysctl value", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting)
 	err = sysctl.Set(sysctl.NFConntrackMax, sysctl.NFConntrackMaxSetting)
 	if err != nil {
 		l.Errorw("unable to set sysctl", "key", sysctl.NFConntrackMax, "value", sysctl.NFConntrackMaxSetting, "error", err)

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -13,17 +13,17 @@ import (
 const (
 	// sysctlBase is the root directory for sysctl values in the proc filesystem
 	sysctlBase = "/proc/sys"
-	// NFConntrackMax defines how many connection track entries can be active at the same time
-	NFConntrackMax = Sysctl("/net/netfilter/nf_conntrack_max")
-	// NFConntrackMaxSetting defines the maximum settable
-	NFConntrackMaxSetting = 4194304
+	// nfConntrackMax defines how many connection track entries can be active at the same time
+	nfConntrackMax = Sysctl("/net/netfilter/nf_conntrack_max")
+	// nfConntrackMaxSetting defines the maximum settable
+	nfConntrackMaxSetting = 4194304
 
 	// moduleBase is the root directory for module specific settings
 	moduleBase = "/sys/module"
-	// NFConntrackHashSize defines the hashsize of the conntrack module
-	NFConntrackHashSize = Module("/nf_conntrack/parameters/hashsize")
-	// NFConntrackHashSizeSetting defines the maximum settable
-	NFConntrackHashSizeSetting = 4194304
+	// nfConntrackHashSize defines the hashsize of the conntrack module
+	nfConntrackHashSize = Module("/nf_conntrack/parameters/hashsize")
+	// nfConntrackHashSizeSetting defines the maximum settable
+	nfConntrackHashSizeSetting = 4194304
 )
 
 type (
@@ -32,26 +32,26 @@ type (
 )
 
 func Tune(log *zap.SugaredLogger) error {
-	log.Infow("set sysctl value", "key", NFConntrackMax, "value", NFConntrackMaxSetting)
-	err := Set(NFConntrackMax, NFConntrackMaxSetting)
+	log.Infow("set sysctl value", "key", nfConntrackMax, "value", nfConntrackMaxSetting)
+	err := Set(nfConntrackMax, nfConntrackMaxSetting)
 	if err != nil {
-		return fmt.Errorf("unable to set value of %q %w", NFConntrackMax, err)
+		return fmt.Errorf("unable to set value of %q %w", nfConntrackMax, err)
 	}
-	conntrackMax, err := Get(NFConntrackMax)
+
+	conntrackMax, err := Get(nfConntrackMax)
 	if err != nil {
-		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
+		return fmt.Errorf("unable to get value of %q %w", nfConntrackMax, err)
 	}
-	log.Infow("set module value", "key", NFConntrackHashSize, "value", NFConntrackHashSizeSetting)
-	err = SetModule(NFConntrackHashSize, NFConntrackHashSizeSetting)
+
+	log.Infow("set module value", "key", nfConntrackHashSize, "value", nfConntrackHashSizeSetting)
+	err = SetModule(nfConntrackHashSize, nfConntrackHashSizeSetting)
 	if err != nil {
 		return fmt.Errorf("unable to set module parameter %w", err)
 	}
+
+	hashSize, err := GetModule(nfConntrackHashSize)
 	if err != nil {
-		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
-	}
-	hashSize, err := GetModule(NFConntrackHashSize)
-	if err != nil {
-		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
+		return fmt.Errorf("unable to get value of %q %w", nfConntrackMax, err)
 	}
 
 	log.Infow("sysctl and module parameters set", "conntrack max", conntrackMax, "hash size", hashSize)

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysctl
+
+import (
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const (
+	sysctlBase = "/proc/sys"
+	// NFConntrackMax defines how many connection track entries can be active at the same time
+	NFConntrackMax = "/net/netfilter/nf_conntrack_max"
+	// NFConntrackMaxSetting defines the maximum settable
+	NFConntrackMaxSetting = 4194304
+)
+
+// GetSysctl returns the value for the specified sysctl setting
+func Get(sysctl string) (int, error) {
+	data, err := os.ReadFile(path.Join(sysctlBase, sysctl))
+	if err != nil {
+		return -1, err
+	}
+	val, err := strconv.Atoi(strings.Trim(string(data), " \n"))
+	if err != nil {
+		return -1, err
+	}
+	return val, nil
+}
+
+// SetSysctl modifies the specified sysctl flag to the new value
+func Set(sysctl string, newVal int) error {
+	return os.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0600)
+}

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,10 +1,13 @@
 package sysctl
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -27,6 +30,33 @@ type (
 	Sysctl string
 	Module string
 )
+
+func Tune(log *zap.SugaredLogger) error {
+	log.Infow("set sysctl value", "key", NFConntrackMax, "value", NFConntrackMaxSetting)
+	err := Set(NFConntrackMax, NFConntrackMaxSetting)
+	if err != nil {
+		return fmt.Errorf("unable to set value of %q %w", NFConntrackMax, err)
+	}
+	conntrackMax, err := Get(NFConntrackMax)
+	if err != nil {
+		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
+	}
+	log.Infow("set module value", "key", NFConntrackHashSize, "value", NFConntrackHashSizeSetting)
+	err = SetModule(NFConntrackHashSize, NFConntrackHashSizeSetting)
+	if err != nil {
+		return fmt.Errorf("unable to set module parameter %w", err)
+	}
+	if err != nil {
+		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
+	}
+	hashSize, err := GetModule(NFConntrackHashSize)
+	if err != nil {
+		return fmt.Errorf("unable to get value of %q %w", NFConntrackMax, err)
+	}
+
+	log.Infow("sysctl and module parameters set", "conntrack max", conntrackMax, "hash size", hashSize)
+	return nil
+}
 
 // Get returns the value for the specified sysctl setting
 func Get(sysctl Sysctl) (int, error) {

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2015 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package sysctl
 
 import (

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -8,16 +8,29 @@ import (
 )
 
 const (
+	// sysctlBase is the root directory for sysctl values in the proc filesystem
 	sysctlBase = "/proc/sys"
 	// NFConntrackMax defines how many connection track entries can be active at the same time
-	NFConntrackMax = "/net/netfilter/nf_conntrack_max"
+	NFConntrackMax = Sysctl("/net/netfilter/nf_conntrack_max")
 	// NFConntrackMaxSetting defines the maximum settable
 	NFConntrackMaxSetting = 4194304
+
+	// moduleBase is the root directory for module specific settings
+	moduleBase = "/sys/module"
+	// NFConntrackHashSize defines the hashsize of the conntrack module
+	NFConntrackHashSize = Module("/nf_conntrack/parameters/hashsize")
+	// NFConntrackHashSizeSetting defines the maximum settable
+	NFConntrackHashSizeSetting = 4194304
+)
+
+type (
+	Sysctl string
+	Module string
 )
 
 // Get returns the value for the specified sysctl setting
-func Get(sysctl string) (int, error) {
-	data, err := os.ReadFile(path.Join(sysctlBase, sysctl))
+func Get(sysctl Sysctl) (int, error) {
+	data, err := os.ReadFile(path.Join(sysctlBase, string(sysctl)))
 	if err != nil {
 		return -1, err
 	}
@@ -29,6 +42,24 @@ func Get(sysctl string) (int, error) {
 }
 
 // Set modifies the specified sysctl flag to the new value
-func Set(sysctl string, newVal int) error {
-	return os.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0600)
+func Set(sysctl Sysctl, newVal int) error {
+	return os.WriteFile(path.Join(sysctlBase, string(sysctl)), []byte(strconv.Itoa(newVal)), 0600)
+}
+
+// GetModule returns the value for the specified Module setting
+func GetModule(module Module) (int, error) {
+	data, err := os.ReadFile(path.Join(moduleBase, string(module)))
+	if err != nil {
+		return -1, err
+	}
+	val, err := strconv.Atoi(strings.Trim(string(data), " \n"))
+	if err != nil {
+		return -1, err
+	}
+	return val, nil
+}
+
+// SetModule modifies the specified module flag to the new value
+func SetModule(module Module, newVal int) error {
+	return os.WriteFile(path.Join(moduleBase, string(module)), []byte(strconv.Itoa(newVal)), 0600)
 }

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -15,7 +15,7 @@ const (
 	NFConntrackMaxSetting = 4194304
 )
 
-// GetSysctl returns the value for the specified sysctl setting
+// Get returns the value for the specified sysctl setting
 func Get(sysctl string) (int, error) {
 	data, err := os.ReadFile(path.Join(sysctlBase, sysctl))
 	if err != nil {
@@ -28,7 +28,7 @@ func Get(sysctl string) (int, error) {
 	return val, nil
 }
 
-// SetSysctl modifies the specified sysctl flag to the new value
+// Set modifies the specified sysctl flag to the new value
 func Set(sysctl string, newVal int) error {
 	return os.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0600)
 }


### PR DESCRIPTION
Solves https://github.com/metal-stack/metal-images/issues/201

before:
```
# cat /proc/sys/net/netfilter/nf_conntrack_max
262144
```

After:
```
Sep 01 09:40:11 shoot--pbs4kr--inttest0-firewall-a67d3 ip[181903]: {"level":"info","timestamp":"2023-09-01T09:40:11+02:00","caller":"sysctl/sysctl.go:35","msg":"set sysctl value","key":"/net/netfilter/nf_conntrack_max","value":4194304}
Sep 01 09:40:11 shoot--pbs4kr--inttest0-firewall-a67d3 ip[181903]: {"level":"info","timestamp":"2023-09-01T09:40:11+02:00","caller":"sysctl/sysctl.go:44","msg":"set module value","key":"/nf_conntrack/parameters/hashsize","value":4194304}
Sep 01 09:40:11 shoot--pbs4kr--inttest0-firewall-a67d3 ip[181903]: {"level":"info","timestamp":"2023-09-01T09:40:11+02:00","caller":"sysctl/sysctl.go:57","msg":"sysctl and module parameters set","conntrack max":4194304,"hash size":4194304}

# cat /proc/sys/net/netfilter/nf_conntrack_max
4194304
# cat /sys/module/nf_conntrack/parameters/hashsize
4194304
```