### PR TITLE
Reconcile firewall at least every three minutes.

### DIFF
--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -139,9 +139,11 @@ func (r *FirewallReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	r.recordFirewallEvent(f, corev1.EventTypeNormal, "Reconciled", "nftables rules and statistics successfully")
 
-	r.Log.Info("successfully reconciled firewall")
+	r.Log.Info("successfully reconciled firewall, requeueing in 3 minutes")
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{
+		RequeueAfter: 3 * time.Minute,
+	}, nil
 }
 
 type firewallService struct {


### PR DESCRIPTION
The firewall resources does not change often so sometimes the reconciliation does not run, leaving firewall services in a wrong state.

Closes #167.