### PR TITLE
Only add no bgp enforce-first-as on frr >= 10

### DIFF
--- a/controllers/firewall_controller.go
+++ b/controllers/firewall_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	mn "github.com/metal-stack/metal-lib/pkg/net"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,8 @@ type FirewallReconciler struct {
 	recordFirewallEvent func(f *firewallv2.Firewall, eventtype, reason, message string)
 
 	SeedUpdatedFunc func()
+
+	FrrVersion *semver.Version
 }
 
 const (
@@ -115,7 +118,7 @@ func (r *FirewallReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	r.Log.Info("reconciling network settings")
 
 	var errs []error
-	changed, err := network.ReconcileNetwork(f)
+	changed, err := network.ReconcileNetwork(f, r.FrrVersion)
 	if changed && err == nil {
 		r.recordFirewallEvent(f, corev1.EventTypeNormal, "Network settings", "reconciliation succeeded (frr.conf)")
 	} else if changed && err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/metal-stack/firewall-controller-manager v0.4.3
 	github.com/metal-stack/metal-go v0.39.4
 	github.com/metal-stack/metal-lib v0.19.0
-	github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7
+	github.com/metal-stack/metal-networker v0.46.1
 	github.com/metal-stack/v v1.0.3
 	github.com/miekg/dns v1.1.62
 	github.com/txn2/txeh v1.5.5

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/fatih/color v1.18.0
 	github.com/go-logr/logr v1.4.2
@@ -14,7 +15,7 @@ require (
 	github.com/metal-stack/firewall-controller-manager v0.4.3
 	github.com/metal-stack/metal-go v0.39.4
 	github.com/metal-stack/metal-lib v0.19.0
-	github.com/metal-stack/metal-networker v0.46.0
+	github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7
 	github.com/metal-stack/v v1.0.3
 	github.com/miekg/dns v1.1.62
 	github.com/txn2/txeh v1.5.5
@@ -31,7 +32,6 @@ require (
 replace k8s.io/apimachinery => k8s.io/apimachinery v0.29.3
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/metal-stack/metal-hammer v0.13.10 h1:p1L2rGeABbjv8jRnua7dYF8nDjLZ+Boh
 github.com/metal-stack/metal-hammer v0.13.10/go.mod h1:cOdArIOW1VBICPX3dlpyg1Wf3PsMeGjyw7mJJmCTqeU=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
-github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7 h1:ObBqtlHOjEQLegHUhY8mFhR3cDEt8zgDMGe68u+5gMQ=
-github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7/go.mod h1:FyG88QowtyZ7J2bBf36HRZsdm7JK1HCNVNrCMU7THQA=
+github.com/metal-stack/metal-networker v0.46.1 h1:X4UKEom7ZU9sY0ndrqWhtfUDR0jShGauCpBXVSzAocY=
+github.com/metal-stack/metal-networker v0.46.1/go.mod h1:FyG88QowtyZ7J2bBf36HRZsdm7JK1HCNVNrCMU7THQA=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=
 github.com/metal-stack/v v1.0.3/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/metal-stack/metal-hammer v0.13.10 h1:p1L2rGeABbjv8jRnua7dYF8nDjLZ+Boh
 github.com/metal-stack/metal-hammer v0.13.10/go.mod h1:cOdArIOW1VBICPX3dlpyg1Wf3PsMeGjyw7mJJmCTqeU=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
-github.com/metal-stack/metal-networker v0.46.0 h1:fRC+LHRWvvYK9ernI6Wasr9wPseVS1s9q7PAVV3JZKc=
-github.com/metal-stack/metal-networker v0.46.0/go.mod h1:C2bsFq4o6p6GwGS2j14/r+nwKGpGSl3uIISzPrhO8+A=
+github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7 h1:ObBqtlHOjEQLegHUhY8mFhR3cDEt8zgDMGe68u+5gMQ=
+github.com/metal-stack/metal-networker v0.46.1-0.20250115094131-585c24b0d8d7/go.mod h1:FyG88QowtyZ7J2bBf36HRZsdm7JK1HCNVNrCMU7THQA=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=
 github.com/metal-stack/v v1.0.3/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=

--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -1,0 +1,48 @@
+package frr
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func DetectVersion() (*semver.Version, error) {
+
+	vtysh, err := exec.LookPath("vtysh")
+	if err != nil {
+		return nil, fmt.Errorf("unable to detect path to vtysh: %w", err)
+	}
+	// $ vtysh -c "show version"|grep FRRouting
+	// FRRouting 10.2.1 (shoot--pz9cjf--mwen-fel-firewall-dcedd) on Linux(6.6.60-060660-generic).
+	c := exec.Command(vtysh, "-c", "show version")
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("unable to detect frr version with dpkg: %w", err)
+	}
+
+	var frrVersion string
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "FRRouting") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		frrVersion = fields[1]
+		break
+	}
+	if frrVersion == "" {
+		return nil, fmt.Errorf("unable to detect frr version")
+	}
+
+	ver, err := semver.NewVersion(frrVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse frr version to semver: %w", err)
+	}
+	return ver, nil
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Masterminds/semver/v3"
 	firewallv2 "github.com/metal-stack/firewall-controller-manager/api/v2"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-networker/pkg/netconf"
@@ -55,7 +56,7 @@ func GetNewNetworks(f *firewallv2.Firewall, oldNetworks []*models.V1MachineNetwo
 
 // ReconcileNetwork reconciles the network settings for a firewall
 // Changes both the FRR-Configuration and Nftable rules when network prefixes or FRR template changes
-func ReconcileNetwork(f *firewallv2.Firewall) (changed bool, err error) {
+func ReconcileNetwork(f *firewallv2.Firewall, frrVersion *semver.Version) (changed bool, err error) {
 	tmpFile, err := tmpFile(frrConfig)
 	if err != nil {
 		return false, fmt.Errorf("error during network reconciliation %v: %w", tmpFile, err)
@@ -70,7 +71,7 @@ func ReconcileNetwork(f *firewallv2.Firewall) (changed bool, err error) {
 	}
 	c.Networks = GetNewNetworks(f, c.Networks)
 
-	a := netconf.NewFrrConfigApplier(netconf.Firewall, *c, tmpFile)
+	a := netconf.NewFrrConfigApplier(netconf.Firewall, *c, tmpFile, frrVersion)
 	tpl := netconf.MustParseTpl(netconf.TplFirewallFRR)
 
 	changed, err = a.Apply(*tpl, tmpFile, frrConfig, true)


### PR DESCRIPTION
## Description

Older firewalls with frr < 10 would break if "no bgp enforce-first-as" is enabled. Make this configuration setting only for newer frr versions.

Depends on:

- [ ] https://github.com/metal-stack/metal-networker/pull/118

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
