### PR TITLE
Firewall should not enforce-first-as for the underlay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/metal-stack/firewall-controller-manager v0.4.3
 	github.com/metal-stack/metal-go v0.39.4
 	github.com/metal-stack/metal-lib v0.19.0
-	github.com/metal-stack/metal-networker v0.46.1
+	github.com/metal-stack/metal-networker v0.46.2-0.20250123073059-cbcd15c32290
 	github.com/metal-stack/v v1.0.3
 	github.com/miekg/dns v1.1.62
 	github.com/txn2/txeh v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/metal-stack/metal-hammer v0.13.10 h1:p1L2rGeABbjv8jRnua7dYF8nDjLZ+Boh
 github.com/metal-stack/metal-hammer v0.13.10/go.mod h1:cOdArIOW1VBICPX3dlpyg1Wf3PsMeGjyw7mJJmCTqeU=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
-github.com/metal-stack/metal-networker v0.46.1 h1:X4UKEom7ZU9sY0ndrqWhtfUDR0jShGauCpBXVSzAocY=
-github.com/metal-stack/metal-networker v0.46.1/go.mod h1:FyG88QowtyZ7J2bBf36HRZsdm7JK1HCNVNrCMU7THQA=
+github.com/metal-stack/metal-networker v0.46.2-0.20250123073059-cbcd15c32290 h1:2Aa5TAnIUoDwpHM1IJPN2nhPsQzit6+mnSaltMGyjA0=
+github.com/metal-stack/metal-networker v0.46.2-0.20250123073059-cbcd15c32290/go.mod h1:FyG88QowtyZ7J2bBf36HRZsdm7JK1HCNVNrCMU7THQA=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=
 github.com/metal-stack/v v1.0.3/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=


### PR DESCRIPTION
## Description

It turns out that adding `no bgp enforce-first-as` to the VRF BGP Instances is not enough to create a stable working firewall upon first start, it still requires a `frr reload` sometimes. We observed that after the reload, this entry was added to the underlay section as well. So do this always.

```NOTEWORTHY
Will reload frr for all existing firewall deployments.
```

Depends on:

- [ ] https://github.com/metal-stack/metal-networker/pull/120

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
